### PR TITLE
feat : remove version from entity to quicken up insertion

### DIFF
--- a/src/main/java/com/learning/mfscreener/entities/MFSchemeEntity.java
+++ b/src/main/java/com/learning/mfscreener/entities/MFSchemeEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +34,6 @@ public class MFSchemeEntity extends AuditableEntity<String> implements Serializa
 
     @Column(name = "scheme_name_alias")
     private String schemeNameAlias;
-
-    @Version
-    private Short version;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mf_scheme_type_id")
@@ -88,15 +84,6 @@ public class MFSchemeEntity extends AuditableEntity<String> implements Serializa
 
     public MFSchemeEntity setSchemeNameAlias(String schemeNameAlias) {
         this.schemeNameAlias = schemeNameAlias;
-        return this;
-    }
-
-    public Short getVersion() {
-        return version;
-    }
-
-    public MFSchemeEntity setVersion(Short version) {
-        this.version = version;
         return this;
     }
 

--- a/src/main/java/com/learning/mfscreener/mapper/MfSchemeDtoToEntityMapper.java
+++ b/src/main/java/com/learning/mfscreener/mapper/MfSchemeDtoToEntityMapper.java
@@ -12,12 +12,12 @@ import java.time.LocalDate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mapstruct.AfterMapping;
-import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(config = MapperSpringConfig.class)
 public abstract class MfSchemeDtoToEntityMapper {
@@ -26,6 +26,9 @@ public abstract class MfSchemeDtoToEntityMapper {
     // Define the regular expressions
     private static final Pattern TYPE_CATEGORY_SUBCATEGORY_PATTERN =
             Pattern.compile("^(.*?)\\((.*?)\\s*-\\s*(.*?)\\)$");
+
+    @Autowired
+    MFSchemeTypeRepository mfSchemeTypeRepository;
 
     @Mapping(target = "mfSchemeTypeEntity", ignore = true)
     @Mapping(target = "mfSchemeNavEntities", ignore = true)
@@ -37,15 +40,10 @@ public abstract class MfSchemeDtoToEntityMapper {
     @Mapping(target = "createdBy", ignore = true)
     @Mapping(target = "payOut", source = "payout")
     @Mapping(target = "schemeId", source = "schemeCode")
-    @Mapping(target = "version", ignore = true)
-    public abstract MFSchemeEntity mapMFSchemeDTOToMFSchemeEntity(
-            MFSchemeDTO scheme, @Context MFSchemeTypeRepository mfSchemeTypeRepository);
+    public abstract MFSchemeEntity mapMFSchemeDTOToMFSchemeEntity(MFSchemeDTO scheme);
 
     @AfterMapping
-    void updateMFScheme(
-            MFSchemeDTO scheme,
-            @MappingTarget MFSchemeEntity mfSchemeEntity,
-            @Context MFSchemeTypeRepository mfSchemeTypeRepository) {
+    void updateMFScheme(MFSchemeDTO scheme, @MappingTarget MFSchemeEntity mfSchemeEntity) {
         MFSchemeNavEntity mfSchemenavEntity = new MFSchemeNavEntity();
         mfSchemenavEntity.setNav("N.A.".equals(scheme.nav()) ? 0F : Float.parseFloat(scheme.nav()));
         mfSchemenavEntity.setNavDate(LocalDate.parse(scheme.date(), AppConstants.FORMATTER_DD_MMM_YYYY));

--- a/src/main/java/com/learning/mfscreener/service/HistoricalNavService.java
+++ b/src/main/java/com/learning/mfscreener/service/HistoricalNavService.java
@@ -9,7 +9,6 @@ import com.learning.mfscreener.exception.NavNotFoundException;
 import com.learning.mfscreener.mapper.MfSchemeDtoToEntityMapper;
 import com.learning.mfscreener.models.MFSchemeDTO;
 import com.learning.mfscreener.models.projection.SchemeNameAndISIN;
-import com.learning.mfscreener.repository.MFSchemeTypeRepository;
 import com.learning.mfscreener.utils.AppConstants;
 import com.learning.mfscreener.utils.LocalDateUtility;
 import java.io.BufferedReader;
@@ -35,19 +34,16 @@ public class HistoricalNavService {
     private static final Logger LOGGER = LoggerFactory.getLogger(HistoricalNavService.class);
 
     private final SchemeService schemeService;
-    private final MFSchemeTypeRepository mfSchemeTypeRepository;
     private final RestClient restClient;
     private final MfSchemeDtoToEntityMapper mfSchemeDtoToEntityMapper;
     private final UserSchemeDetailsService userSchemeDetailsService;
 
     public HistoricalNavService(
             SchemeService schemeService,
-            MFSchemeTypeRepository mfSchemeTypeRepository,
             RestClient restClient,
             MfSchemeDtoToEntityMapper mfSchemeDtoToEntityMapper,
             UserSchemeDetailsService userSchemeDetailsService) {
         this.schemeService = schemeService;
-        this.mfSchemeTypeRepository = mfSchemeTypeRepository;
         this.restClient = restClient;
         this.mfSchemeDtoToEntityMapper = mfSchemeDtoToEntityMapper;
         this.userSchemeDetailsService = userSchemeDetailsService;
@@ -201,7 +197,7 @@ public class HistoricalNavService {
             String schemeName = tokenize[1];
             MFSchemeDTO mfSchemeDTO =
                     new MFSchemeDTO(amc, Long.valueOf(schemeCode), payout, schemeName, nav, date, schemeType);
-            return mfSchemeDtoToEntityMapper.mapMFSchemeDTOToMFSchemeEntity(mfSchemeDTO, mfSchemeTypeRepository);
+            return mfSchemeDtoToEntityMapper.mapMFSchemeDTOToMFSchemeEntity(mfSchemeDTO);
         } else {
             MFSchemeNavEntity mfSchemenavEntity = new MFSchemeNavEntity();
             mfSchemenavEntity.setNav("N.A.".equals(nav) ? 0F : Float.parseFloat(nav));

--- a/src/main/resources/db/changelog/migration/01-initilize_db.xml
+++ b/src/main/resources/db/changelog/migration/01-initilize_db.xml
@@ -26,7 +26,6 @@
             <column name="pay_out" type="${string.type}"/>
             <column name="scheme_name_alias" type="${string.type}"/>
             <column name="mf_scheme_type_id" type="INT"/>
-            <column name="version" type="tinyint"/>
             <column name="created_by" type="${string.type}"/>
             <column name="created_date" type="DATETIME"/>
             <column name="last_modified_by" type="${string.type}"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed version control fields and methods from the `MFSchemeEntity` class.
	- Updated dependency injections and method signatures in `MfSchemeDtoToEntityMapper` for cleaner and more efficient code.
	- Simplified constructor in `HistoricalNavService` by removing unnecessary repository dependency.

- **Database Changes**
	- Removed the `version` column from the database schema to streamline data storage.

- **Bug Fixes**
	- Adjusted method calls in `HistoricalNavService` to align with updated dependency injections, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->