### PR TITLE
feat : split testcontainers config for reusability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,16 @@ This overview and class diagram provide a conceptual understanding of the projec
 ```shell
 ./gradlew clean test integrationTest
 ```
-### Run locally
+### Run locally with docker
 
 ```shell
 docker-compose -f docker/docker-compose.yml up -d
+./gradlew bootRun -Plocaldocker
+```
+
+### Run locally
+
+```shell
 ./gradlew bootRun -Plocal
 ```
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   postgresqldb:
-    image: postgres:16-alpine
+    image: postgres:16.3-alpine
     hostname: postgresqldb
     container_name: postgresqldb
     extra_hosts: [ 'host.docker.internal:host-gateway' ]

--- a/src/test/java/com/learning/mfscreener/TestApplication.java
+++ b/src/test/java/com/learning/mfscreener/TestApplication.java
@@ -1,33 +1,15 @@
 package com.learning.mfscreener;
 
-import com.redis.testcontainers.RedisContainer;
+import com.learning.mfscreener.common.NonSQLContainersConfig;
+import com.learning.mfscreener.common.SQLContainersConfig;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.devtools.restart.RestartScope;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@TestConfiguration(proxyBeanMethods = false)
 public class TestApplication {
-
-    @Bean
-    @ServiceConnection(name = "redis")
-    @RestartScope
-    RedisContainer redisContainer() {
-        return new RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME.withTag("7.2.5-alpine"));
-    }
-
-    @Bean
-    @ServiceConnection
-    @RestartScope
-    PostgreSQLContainer<?> postgreSQLContainer() {
-        return new PostgreSQLContainer<>(DockerImageName.parse("postgres").withTag("16-alpine"));
-    }
 
     public static void main(String[] args) {
         System.setProperty("spring.profiles.active", "test");
-        SpringApplication.from(Application::main).with(TestApplication.class).run(args);
+        SpringApplication.from(Application::main)
+                .with(NonSQLContainersConfig.class, SQLContainersConfig.class)
+                .run(args);
     }
 }

--- a/src/test/java/com/learning/mfscreener/common/AbstractIntegrationTest.java
+++ b/src/test/java/com/learning/mfscreener/common/AbstractIntegrationTest.java
@@ -4,7 +4,6 @@ import static com.learning.mfscreener.utils.AppConstants.PROFILE_TEST;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.learning.mfscreener.TestApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles({PROFILE_TEST})
 @SpringBootTest(
         webEnvironment = RANDOM_PORT,
-        classes = {TestApplication.class})
+        classes = {SQLContainersConfig.class, NonSQLContainersConfig.class})
 @AutoConfigureMockMvc
 public abstract class AbstractIntegrationTest {
 

--- a/src/test/java/com/learning/mfscreener/common/NonSQLContainersConfig.java
+++ b/src/test/java/com/learning/mfscreener/common/NonSQLContainersConfig.java
@@ -1,0 +1,18 @@
+package com.learning.mfscreener.common;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class NonSQLContainersConfig {
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    @RestartScope
+    RedisContainer redisContainer() {
+        return new RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME.withTag("7.4.0-alpine"));
+    }
+}

--- a/src/test/java/com/learning/mfscreener/common/SQLContainersConfig.java
+++ b/src/test/java/com/learning/mfscreener/common/SQLContainersConfig.java
@@ -1,0 +1,19 @@
+package com.learning.mfscreener.common;
+
+import org.springframework.boot.devtools.restart.RestartScope;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class SQLContainersConfig {
+
+    @Bean
+    @ServiceConnection
+    @RestartScope
+    PostgreSQLContainer<?> postgreSQLContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres").withTag("16.3-alpine"));
+    }
+}

--- a/src/test/java/com/learning/mfscreener/repository/SchemaValidationPostgresTest.java
+++ b/src/test/java/com/learning/mfscreener/repository/SchemaValidationPostgresTest.java
@@ -2,24 +2,23 @@ package com.learning.mfscreener.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import jakarta.persistence.EntityManager;
+import com.learning.mfscreener.common.SQLContainersConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
-@DataJpaTest(
-        properties = {
-            "spring.jpa.hibernate.ddl-auto=validate",
-            "spring.test.database.replace=none",
-            "spring.datasource.url=jdbc:tc:postgresql:16-alpine:///db"
-        })
+@DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=validate", "spring.test.database.replace=none"})
+@Import(SQLContainersConfig.class)
 class SchemaValidationPostgresTest {
 
     @Autowired
-    EntityManager entityManager;
+    DataSource dataSource;
 
     @Test
-    void schemaValidity() {
-        assertThat(entityManager).isNotNull();
+    void validateJpaMappingsWithDbSchema() {
+        assertThat(dataSource).isNotNull().isInstanceOf(HikariDataSource.class);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated the README to emphasize local development with Docker and added a new command for running the application.
  
- **New Features**
  - Introduced `NonSQLContainersConfig` and `SQLContainersConfig` classes to enhance testing capabilities with Redis and PostgreSQL containers.
  
- **Bug Fixes**
  - Updated PostgreSQL image version in Docker Compose to `16.3-alpine` for improved stability and compatibility.
  
- **Tests**
  - Enhanced test configurations by replacing `EntityManager` with `DataSource` and refining test method names for clarity.
  - Modified integration test setup to use specialized SQL and Non-SQL configuration classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->